### PR TITLE
add basic pr template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,1 +1,11 @@
+## Reason for PR (link to ticket if one exists)
+[EL-#]
+
+## Description of changes
+
+
+## Screenshots (for visual changes)
+
+
+## Testing (manual or automated)
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,11 +1,12 @@
-## Reason for PR (link to ticket if one exists)
+### Reason for PR 
+link to ticket if one exists
 [EL-#]
 
-## Description of changes
+### Description of changes
+include dependency changes
 
+### Screenshots
+for visual changes
 
-## Screenshots (for visual changes)
-
-
-## Testing (manual or automated)
-
+### Testing
+manual or automated


### PR DESCRIPTION
### Reason for PR 
Parabol task; encourages standard documentation to help teammates quickly understand your changes.
If there were a Jira ticket, I would include its tag here (e.g. `[JIRA-001]`) and that would automatically generate a link to the relevant ticket.

### Description of changes
Added to public [.github](https://github.com/visio-media/.github) repo, which means it will be applied automatically to all new PRs in any @visio-media repository. Unfortunately, this repository [must be public](https://github.community/t/private-org-wide-issue-templates/122591/2) for now.

### Screenshots
N/A

### Testing
Here would go notes on what tests I added or what the reviewer might want to keep in mind while manually testing the code. Ideally, this should remind the submitter (and hopefully not too late) to consider automated tests.